### PR TITLE
Differentiate BXR and BRW files

### DIFF
--- a/bwpy/__init__.py
+++ b/bwpy/__init__.py
@@ -35,6 +35,19 @@ class File(h5py.File):
     def version(self):
         return self.attrs["Version"]
 
+    @property
+    def guid(self):
+        return self.attrs["GUID"].decode()
 
 
-__all__ = ["File"]
+class BRWFile(File):
+    def _get_descr_prefix(self):
+        return "BRW-File Level3"
+
+
+class BXRFile(File):
+    def _get_descr_prefix(self):
+        return "BXR-File Level2"
+
+
+__all__ = ["File", "BRWFile", "BXRFile"]

--- a/bwpy/__init__.py
+++ b/bwpy/__init__.py
@@ -35,12 +35,14 @@ class File(h5py.File):
     @description.setter
     @requires_write_access
     def description(self, value):
-        if not value.startswith("BRW-File Level3"):
+        prefix = self._get_descr_prefix()
+        if not value.startswith(prefix):
             warnings.warn(
-                "File descriptions must start with 'BRW-File Level3'. Prepended 'BRW-File Level3 - ' to the description.",
+                f"File descriptions must start with '{prefix}'. "
+                + f"Prepended '{prefix} - ' to the description.",
                 stacklevel=2,
             )
-            value = "BRW-File Level3 - " + value
+            value = f"{prefix} - " + value
         utf8_type = h5py.string_dtype("utf-8", len(value))
         value = np.array(value.encode("utf-8"), dtype=utf8_type)
         self.attrs["Description"] = value

--- a/bwpy/__init__.py
+++ b/bwpy/__init__.py
@@ -5,14 +5,28 @@ from ._hdf_annotations import requires_write_access
 
 __version__ = "0.0.1a0"
 
-
 class File(h5py.File):
-    def __new__(cls, *args, **kwargs):
-        # TODO: Take a peek and check whether we should make a BRWFile or BXRFile
-        return super().__new__(cls)
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._establish_type()
+
+    @property
+    def type(self):
+        if hasattr(self, "_type"):
+            return self._type
+        self._establish_type()
+        if hasattr(self, "_type"):
+            return self._type
+        else:
+            return None
+
+    def _establish_type(self):
+        if "3BData" in self:
+            self.__class__ = BRWFile
+            self._type = "brw"
+        if "3BResults" in self:
+            self.__class__ = BXRFile
+            self._type = "bxr"
 
     @property
     def description(self):

--- a/bwpy/__init__.py
+++ b/bwpy/__init__.py
@@ -35,8 +35,6 @@ class File(h5py.File):
     def version(self):
         return self.attrs["Version"]
 
-    def get_channels(self):
-        return self.keys()
 
 
 __all__ = ["File"]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -12,5 +12,5 @@ def open_sample(sample, *args, **kwargs):
 
 def open_sample_copy(sample):
     return bwpy.File(
-        get_sample_path(sample), mode="w", driver="core", backing_store=False
+        get_sample_path(sample), mode="a", driver="core", backing_store=False
     )

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -9,6 +9,14 @@ class TestFileObjects(unittest.TestCase):
         with bwpy.File(get_sample_path("truncated_brw.brw"), "r") as file:
             pass
 
+    def test_brw_type(self):
+        with bwpy.File(get_sample_path("truncated_brw.brw"), "r") as file:
+            self.assertEqual("brw", file.type)
+
+    def test_bxr_type(self):
+        with bwpy.File(get_sample_path("sample.bxr"), "r") as file:
+            self.assertEqual("bxr", file.type)
+
 
 class TestFileObjectProperties(unittest.TestCase):
     def test_description(self):
@@ -32,3 +40,9 @@ class TestFileObjectProperties(unittest.TestCase):
             version = f.version
         self.assertEqual(numpy.int32, type(version))
         self.assertEqual(version, 320)
+
+    def test_guid(self):
+        with open_sample("truncated_brw.brw", "r") as f:
+            guid = f.guid
+        self.assertIs(str, type(guid), "GUID should be of type str.")
+        self.assertEqual("cfef184e-a0ea-41af-976b-45dcec62d561", guid)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -15,13 +15,13 @@ class TestFileObjectProperties(unittest.TestCase):
         with open_sample("truncated_brw.brw", "r") as f:
             descr = f.description
         self.assertIs(str, type(descr), "Description should be of type str.")
-        with open_sample_copy("truncated_brw") as f:
+        with open_sample_copy("truncated_brw.brw") as f:
             f.description = "BRW-File Level3 - Hi, I'm Elfo"
             descr = f.description
         self.assertEqual(descr, "BRW-File Level3 - Hi, I'm Elfo")
 
     def test_description_prefix(self):
-        with open_sample_copy("truncated_brw") as f:
+        with open_sample_copy("truncated_brw.brw") as f:
             with self.assertWarns(UserWarning):
                 f.description = "Hi, I'm Elfo"
             descr = f.description


### PR DESCRIPTION
The `File` constructor will try to establish whether it's a `BXR` or `BRW` file and change the class of the object accordingly.