### PR TITLE
CI can now build h5py==2.10.0 for Python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,16 +24,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
-    - name: Install 7zip
+    - name: Install apt packages
       run: |
-        sudo add-apt-repository universe
         sudo apt-get update
-        sudo apt-get install p7zip-full p7zip-rar
-    # - name: Download example data
-    #   run: |
-    #     wget https://resources.3brain.com/f1/downloads/DataSet_05_Slice_3Sec.7z -O sample.7z
-    #     7z e sample.7z -y
-    #     mv DataSet_05_Slice_3sec.brw tests/test_samples/sample.brw
+        sudo apt-get install libhdf5-dev
     - name: Install dependencies & self
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
BXR files require to be read with h5py<3.0.0 (see #3) but no wheels exist for Python 3.9 for these versions. Therefor the CI pipeline now apt-get installs `libhdf5-dev` so that `h5py` wheels can be built by pip on the Python 3.9 job.